### PR TITLE
Add documentation main page and cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ NeoFaker is available on [Hex](https://hex.pm/packages/neo_faker). Add it to you
 ```elixir
 def deps do
   [
-    {:neo_faker, "~> 0.4.4", only: [:dev, :test], runtime: false}
+    {:neo_faker, "~> 0.5.0", only: [:dev, :test], runtime: false}
   ]
 end
 ```

--- a/lib/nf/app.ex
+++ b/lib/nf/app.ex
@@ -61,18 +61,6 @@ defmodule Nf.App do
       iex> Nf.App.name(style: :camel_case)
       "neoFaker"
 
-      iex> Nf.App.name(style: :pascal_case)
-      "NeoFaker"
-
-      iex> Nf.App.name(style: :dashed)
-      "Neo-faker"
-
-      iex> Nf.App.name(style: :underscore)
-      "neo_faker"
-
-      iex> Nf.App.name(style: :single)
-      "Faker"
-
   """
   @spec name(Keyword.t()) :: String.t()
   def name(opts \\ []) do
@@ -138,12 +126,6 @@ defmodule Nf.App do
 
       iex> Nf.App.semver(:pre_release)
       "1.2.3-beta.1"
-
-      iex> Nf.App.semver(:build)
-      "1.2.3+20250325"
-
-      iex> Nf.App.semver(:pre_release_build)
-      "1.2.3-rc.1+20250325"
 
   """
   @spec semver(Keyword.t()) :: String.t()

--- a/lib/nf/app.ex
+++ b/lib/nf/app.ex
@@ -50,6 +50,7 @@ defmodule Nf.App do
   - `:camel_case` - Uses camel case, e.g., `"neoFaker"`.
   - `:pascal_case` - Uses Pascal case, e.g., `"NeoFaker"`.
   - `:dashed` - Uses a dashed style, e.g., `"Neo-faker"`.
+  - `:underscore` - Uses an underscore style, e.g., `"neo_faker"`.
   - `:single` - Uses a single-word format, e.g., `"Faker"`.
 
   ## Examples
@@ -65,6 +66,9 @@ defmodule Nf.App do
 
       iex> Nf.App.name(style: :dashed)
       "Neo-faker"
+
+      iex> Nf.App.name(style: :underscore)
+      "neo_faker"
 
       iex> Nf.App.name(style: :single)
       "Faker"
@@ -83,6 +87,7 @@ defmodule Nf.App do
       :camel_case -> "#{String.downcase(first_name)}#{String.capitalize(last_name)}"
       :pascal_case -> "#{String.capitalize(first_name)}#{String.capitalize(last_name)}"
       :dashed -> "#{String.capitalize(first_name)}-#{last_name}"
+      :underscore -> "#{String.downcase(first_name)}_#{String.downcase(last_name)}"
       :single -> [first_name, last_name] |> Enum.random() |> String.capitalize()
     end
   end

--- a/lib/nf/blood.ex
+++ b/lib/nf/blood.ex
@@ -17,8 +17,8 @@ defmodule Nf.Blood do
 
   ## Examples
 
-    iex> Nf.Blood.group()
-    "B+"
+      iex> Nf.Blood.group()
+      "B+"
 
   """
   @spec group() :: String.t()
@@ -31,8 +31,8 @@ defmodule Nf.Blood do
 
   ## Examples
 
-    iex> Nf.Blood.type()
-    "B"
+      iex> Nf.Blood.type()
+      "B"
 
   """
   @spec type() :: String.t()

--- a/lib/nf/crypto.ex
+++ b/lib/nf/crypto.ex
@@ -26,7 +26,7 @@ defmodule Nf.Crypto do
 
   ## Examples
 
-      iex> Nf.Hash.md5()
+      iex> Nf.Crypto.md5()
       "e35cb102765cfc56df21ba4c16e6a636"
 
   """
@@ -42,7 +42,7 @@ defmodule Nf.Crypto do
 
   ## Examples
 
-      iex> Nf.Hash.sha1()
+      iex> Nf.Crypto.sha1()
       "c8719790cdfff41c37c75e0c848d2b57535255aa"
 
   """
@@ -58,7 +58,7 @@ defmodule Nf.Crypto do
 
   ## Examples
 
-      iex> Nf.Hash.sha256()
+      iex> Nf.Crypto.sha256()
       "d0ff021e810fb8f3442a14393604b0661b02f0dfcb347d80c9580af3ab5e7e6c"
 
   """

--- a/lib/nf/gravatar.ex
+++ b/lib/nf/gravatar.ex
@@ -19,21 +19,17 @@ defmodule Nf.Gravatar do
 
   ## Options
 
-  The following options are available:
+  The accepted options are:
 
   - `:size` - Defines the image size.
   - `:fallback` - Specifies the default fallback image.
 
-  ### `:size`
-
-  Defines the image size.
+  The values for `:size` can be:
 
   - `nil` (default) - Uses 80px.
   - `integer` - The image size in pixels (valid range: `1` to `2048`).
 
-  ### `:fallback`
-
-  Specifies the default fallback image.
+  The values for `:fallback` can be:
 
   - `nil` (default) - Uses `"identicon"`.
   - `:identicon` - Generates an "identicon".
@@ -44,16 +40,16 @@ defmodule Nf.Gravatar do
   ## Examples
 
       iex> Nf.Gravatar.display()
-      "https://gravatar.com/avatar/836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f?d=identicon&s=80"
+      "https://gravatar.com/avatar/<hashed_email>?d=identicon&s=80"
 
       iex> Nf.Gravatar.display("john.doe@example.com")
-      "https://gravatar.com/avatar/836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f?d=identicon&s=80"
+      "https://gravatar.com/avatar/<hashed_email>?d=identicon&s=80"
 
       iex> Nf.Gravatar.display("john.doe@example.com", size: 100)
-      "https://gravatar.com/avatar/836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f?d=identicon&s=100"
+      "https://gravatar.com/avatar/<hashed_email>?d=identicon&s=100"
 
-      iex> Nf.Gravatar.display("john.doe@example.com", fallback: "monsterid")
-      "https://gravatar.com/avatar/836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f?d=monsterid&s=80"
+      iex> Nf.Gravatar.display("john.doe@example.com", fallback: :monsterid)
+      "https://gravatar.com/avatar/<hashed_email>?d=monsterid&s=80"
 
   """
   @spec display(email(), Keyword.t()) :: String.t()

--- a/lib/nf/helper.ex
+++ b/lib/nf/helper.ex
@@ -4,11 +4,11 @@ defmodule Nf.Helper do
   """
   @moduledoc since: "0.4.1"
 
-  @typedoc "Path to the `priv/lib` directory"
+  @typedoc "Path to the `lib/data/` directory"
   @type exs_path :: list(String.t())
 
   @doc """
-  Returns the absolute path to the `lib/data/` directory.
+  Returns the absolute path to the `lib/data` directory.
 
   This path is useful for loading dynamic files, such as `.exs` scripts.
   """
@@ -16,7 +16,7 @@ defmodule Nf.Helper do
   def get_data_path, do: Path.join([File.cwd!(), "lib", "data"])
 
   @doc """
-  Reads an `.exs` script file from the `lib/data/` directory and returns its contents as a map.
+  Reads an `.exs` script file from the `lib/data` directory and returns its contents as a map.
   """
   @spec read_exs_file!(exs_path(), String.t()) :: map()
   def read_exs_file!(path, file_name) do

--- a/lib/pages/cheat-sheet/cheat.cheatmd
+++ b/lib/pages/cheat-sheet/cheat.cheatmd
@@ -1,0 +1,129 @@
+# Cheat Sheet
+
+This page provides a quick reference for common functions in the NeoFaker package.
+
+## [App](`Nf.App`)
+
+{: .col-2}
+
+### [`author()`](`Nf.App.author/0`)
+
+```elixir
+iex> Nf.App.author()
+"José Valim"
+```
+
+### [`description()`](`Nf.App.description/0`)
+
+```elixir
+iex> Nf.App.description()
+"Elixir library for generating fake data in tests and development."
+```
+
+### [`license()`](`Nf.App.license/0`)
+
+```elixir
+iex> Nf.App.license()
+"MIT License"
+```
+
+### [`name(opts \\ [])`](`Nf.App.name/1`)
+
+```elixir
+iex> Nf.App.name()
+"Neo Faker"
+
+iex> Nf.App.name(style: :camel_case)
+"neoFaker"
+```
+
+### [`semver(opts \\ [])`](`Nf.App.semver/1`)
+
+```elixir
+iex> Nf.App.semver()
+"1.2.3"
+
+iex> Nf.App.semver(:pre_release)
+"1.2.3-beta.1"
+```
+
+### [`version()`](`Nf.App.version/0`)
+
+```elixir
+iex> Nf.App.version()
+"1.2"
+```
+
+## [Blood](`Nf.Blood`)
+
+{: .col-2}
+
+### [`group()`](`Nf.Blood.group/0`)
+
+```elixir
+iex> Nf.Blood.group()
+"B+"
+```
+
+### [`type()`](`Nf.Blood.type/0`)
+
+```elixir
+iex> Nf.Blood.type()
+"B"
+```
+
+## [Boolean](`Nf.Boolean`)
+
+{: .col-1}
+
+### [`boolean(true_ratio \\ 50)`](`Nf.Boolean.boolean/1`)
+
+```elixir
+iex> Nf.Boolean.boolean()
+false
+
+iex> Nf.Boolean.boolean(75)
+true
+```
+
+## [Crypto](`Nf.Crypto`)
+
+{: .col-2}
+
+### [`md5(opts \\ [])`](`Nf.Crypto.md5/1`)
+
+```elixir
+iex> Nf.Crypto.md5()
+"e35cb102765cfc56df21ba4c16e6a636"
+
+iex> Nf.Crypto.md5(case: :upper)
+"E35CB102765CFC56DF21BA4C16E6A636"
+```
+
+### [`sha1(opts \\ [])`](`Nf.Crypto.sha1/1`)
+
+```elixir
+iex> Nf.Crypto.sha1()
+"c8719790cdfff41c37c75e0c848d2b57535255aa"
+```
+
+### [`sha256(opts \\ [])`](`Nf.Crypto.sha256/1`)
+
+```elixir
+iex> Nf.Crypto.sha256()
+"d0ff021e810fb8f3442a14393604b0661b02f0dfcb347d80c9580af3ab5e7e6c"
+```
+
+## [Gravatar](`Nf.Gravatar`)
+
+{: .col-1}
+
+### [`display(email \\ nil, opts \\ [])`](`Nf.Gravatar.display/2`)
+
+```elixir
+iex> Nf.Gravatar.display()
+"https://gravatar.com/avatar/<hashed_email>?d=identicon&s=80"
+
+iex> Nf.Gravatar.display("john.doe@example.com", fallback: :monsterid)
+"https://gravatar.com/avatar/<hashed_email>?d=monsterid&s=80"
+```

--- a/lib/pages/getting-started.md
+++ b/lib/pages/getting-started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+![Hex.pm Version](https://img.shields.io/hexpm/v/neo_faker)
+![Hex.pm Downloads](https://img.shields.io/hexpm/dt/neo_faker)
+[![Elixir CI](https://github.com/muzhawir/neo_faker/actions/workflows/elixir.yml/badge.svg?branch=main)](https://github.com/muzhawir/neo_faker/actions/workflows/elixir.yml)
+
+**NeoFaker** is an Elixir package for generating fake data for testing and development.
+
+> #### Warning {: .warning}
+>
+> This project is still in early development. Expect breaking changes.
+
+## Installation
+
+Add `:neo_faker` to your dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:neo_faker, "~> 0.4.4", only: [:dev, :test], runtime: false}
+  ]
+end
+```
+
+Then, fetch the dependencies:
+
+```sh
+mix deps.get
+```
+
+## Usage
+
+Here are some examples of how to use NeoFaker:
+
+```elixir
+iex> Nf.App.name()
+"Neo Faker"
+
+iex> Nf.App.description()
+"Elixir library for generating fake data in tests and development."
+```
+
+For a complete list of available functions, check out the [API Reference](api-reference.html).
+
+
+## License
+
+NeoFaker is licensed under the [MIT License](https://github.com/muzhawir/neo_faker/blob/main/LICENSE.md).

--- a/lib/pages/getting-started.md
+++ b/lib/pages/getting-started.md
@@ -17,7 +17,7 @@ Add `:neo_faker` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:neo_faker, "~> 0.4.4", only: [:dev, :test], runtime: false}
+    {:neo_faker, "~> 0.5.1", only: [:dev, :test], runtime: false}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule NeoFaker.MixProject do
       logo: "./lib/assets/logo/doc_logo.svg",
       extras: [
         "./lib/pages/getting-started.md",
-        "./lib/pages/cheat.cheatmd"
+        "./lib/pages/cheat-sheet/cheat.cheatmd"
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NeoFaker.MixProject do
   def project do
     [
       app: :neo_faker,
-      version: "0.4.4",
+      version: "0.5.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -30,9 +30,12 @@ defmodule NeoFaker.MixProject do
 
   defp docs do
     [
-      # main: "readme",
-      logo: "./lib/assets/logo/doc_logo.svg"
-      # extras: ["README.md"]
+      main: "getting-started",
+      logo: "./lib/assets/logo/doc_logo.svg",
+      extras: [
+        "./lib/pages/getting-started.md",
+        "./lib/pages/cheat.cheatmd"
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR introduces the following changes:

- Add `getting-started.md` as the main documentation entry point.
- Add `cheat.cheatmd` as a cheat sheet for quick reference.