### PR TITLE
Add Locale Random Generators

### DIFF
--- a/lib/neo_faker/en_us/person.ex
+++ b/lib/neo_faker/en_us/person.ex
@@ -1,13 +1,39 @@
 defmodule NeoFaker.EnUs.Person do
   @moduledoc """
-  Testing EN US generator
+  Provides functions for generating person-related information specific to the United States
+  locale.
+
+  This module offers a variety of functions to generate random personal details specific to the
+  United States, such as Social Security Numbers (SSNs), among others.
   """
-  import NeoFaker.Helper.Generator
+
+  alias NeoFaker.Number
 
   @doc """
-  should return a random first name
+  Generates a random SSN.
+
+  Returns a random SSN (Social Security Number).
+
+  ## Examples
+
+      iex> NeoFaker.EnUs.Person.ssn()
+      "184-63-2006"
+
   """
-  def first_name do
-    random(NeoFaker.EnUs.Person, "gender.exs", "non_binary")
+  def ssn do
+    group_number = 1 |> Number.between(99) |> to_string() |> String.pad_leading(2, "0")
+    serial_number = 1 |> Number.between(9999) |> to_string() |> String.pad_leading(4, "0")
+
+    "#{area_number()}-#{group_number}-#{serial_number}"
+  end
+
+  # Generate a random area number, if the area number is 666, generate a new area number.
+  defp area_number do
+    number = Number.between(1, 899)
+
+    case number do
+      666 -> 1 |> Number.between(899) |> to_string() |> String.pad_leading(3, "0")
+      _ -> number |> to_string() |> String.pad_leading(3, "0")
+    end
   end
 end

--- a/lib/neo_faker/en_us/person.ex
+++ b/lib/neo_faker/en_us/person.ex
@@ -1,0 +1,13 @@
+defmodule NeoFaker.EnUs.Person do
+  @moduledoc """
+  Testing EN US generator
+  """
+  import NeoFaker.Helper.Generator
+
+  @doc """
+  should return a random first name
+  """
+  def first_name do
+    random(NeoFaker.EnUs.Person, "gender.exs", "non_binary")
+  end
+end

--- a/lib/neo_faker/id_id/person.ex
+++ b/lib/neo_faker/id_id/person.ex
@@ -1,15 +1,15 @@
 defmodule NeoFaker.IdId.Person do
   @moduledoc """
-  Provides functions for generating Indonesian locale specific person-related information.
+  Provides functions for generating person-related information specific to the Indonesian locale.
 
   This module offers a variety of functions to generate random personal details specific to
-  the Indonesian locale, such as NIK (Nomor Induk Kependudukan), etc.
+  Indonesia, such as Nomor Induk Kependudukan (NIK), among others.
   """
 
   alias NeoFaker.IdId.Person.Utils
 
   @doc """
-  Generate a random NIK.
+  Generates a random NIK.
 
   Returns a random NIK (Nomor Induk Kependudukan).
 

--- a/lib/neo_faker/id_id/person.ex
+++ b/lib/neo_faker/id_id/person.ex
@@ -1,0 +1,24 @@
+defmodule NeoFaker.IdId.Person do
+  @moduledoc """
+  Provides functions for generating Indonesian locale specific person-related information.
+
+  This module offers a variety of functions to generate random personal details specific to
+  the Indonesian locale, such as NIK (Nomor Induk Kependudukan), etc.
+  """
+
+  alias NeoFaker.IdId.Person.Utils
+
+  @doc """
+  Generate a random NIK.
+
+  Returns a random NIK (Nomor Induk Kependudukan).
+
+  ## Examples
+
+      iex> NeoFaker.IdId.Person.nik()
+      "7645504903500640"
+
+  """
+  @spec nik() :: String.t()
+  defdelegate nik(), to: Utils, as: :nik
+end

--- a/lib/neo_faker/id_id/person/utils.ex
+++ b/lib/neo_faker/id_id/person/utils.ex
@@ -12,12 +12,12 @@ defmodule NeoFaker.IdId.Person.Utils do
   """
   @spec nik() :: String.t()
   def nik do
-    province_code = Number.between(11, 92)
-    regency_code = 1 |> Number.between(79) |> to_string() |> String.pad_leading(2, "0")
-    district_code = 1 |> Number.between(53) |> to_string() |> String.pad_leading(2, "0")
+    province_number = Number.between(11, 92)
+    regency_number = 1 |> Number.between(79) |> to_string() |> String.pad_leading(2, "0")
+    district_number = 1 |> Number.between(53) |> to_string() |> String.pad_leading(2, "0")
     serial_number = 1 |> Number.between(9999) |> to_string() |> String.pad_leading(4, "0")
 
-    "#{province_code}#{regency_code}#{district_code}#{birth_date()}#{serial_number}"
+    "#{province_number}#{regency_number}#{district_number}#{birth_date()}#{serial_number}"
   end
 
   # Generate a random birth date with either the exact day or the day + 40 (for the female code).

--- a/lib/neo_faker/id_id/person/utils.ex
+++ b/lib/neo_faker/id_id/person/utils.ex
@@ -1,0 +1,39 @@
+defmodule NeoFaker.IdId.Person.Utils do
+  @moduledoc false
+  alias NeoFaker.Number
+
+  @min_age_years -90
+  @max_age_years -18
+
+  @doc """
+  Generate a random NIK.
+
+  This function delegates the call to `NeoFaker.IdId.Person.nik/0`.
+  """
+  @spec nik() :: String.t()
+  def nik do
+    province_code = Number.between(11, 92)
+    regency_code = 1 |> Number.between(79) |> to_string() |> String.pad_leading(2, "0")
+    district_code = 1 |> Number.between(53) |> to_string() |> String.pad_leading(2, "0")
+    serial_number = 1 |> Number.between(9999) |> to_string() |> String.pad_leading(4, "0")
+
+    "#{province_code}#{regency_code}#{district_code}#{birth_date()}#{serial_number}"
+  end
+
+  # Generate a random birth date with either the exact day or the day + 40 (for the female code).
+  defp birth_date do
+    today = Date.utc_today()
+
+    %Date{year: year, month: month, day: day} =
+      today
+      |> Date.shift(year: @min_age_years)
+      |> Date.range(Date.shift(today, year: @max_age_years))
+      |> Enum.random()
+
+    formatted_year = year |> Integer.to_string() |> String.slice(2, 2)
+    formatted_month = month |> Integer.to_string() |> String.pad_leading(2, "0")
+    formatted_day = Enum.random([day, day + 40])
+
+    "#{formatted_day}#{formatted_month}#{formatted_year}"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -44,6 +44,7 @@ defmodule NeoFaker.MixProject do
 
   defp groups_for_modules do
     [
+      "Locale Random Generator": ~r/^NeoFaker\.[A-Z][a-z][A-Z][a-z]\..+/,
       "Random Generators": ~r/^NeoFaker/
     ]
   end

--- a/test/neo_faker/en_us/person_test.exs
+++ b/test/neo_faker/en_us/person_test.exs
@@ -1,0 +1,15 @@
+defmodule NeoFaker.EnUs.PersonTest do
+  use ExUnit.Case, async: true
+
+  alias NeoFaker.EnUs.Person
+
+  @ssn_regexp ~r/^\d{3}-\d{2}-\d{4}$/
+
+  describe "ssn/0" do
+    test "returns a random SSN" do
+      ssn = Person.ssn()
+
+      assert is_binary(ssn) and Regex.match?(@ssn_regexp, ssn)
+    end
+  end
+end

--- a/test/neo_faker/id_id/person_test.exs
+++ b/test/neo_faker/id_id/person_test.exs
@@ -1,0 +1,11 @@
+defmodule NeoFaker.IdId.PersonTest do
+  use ExUnit.Case, async: true
+
+  alias NeoFaker.IdId.Person
+
+  describe "nik/0" do
+    test "returns a random NIK" do
+      assert is_binary(Person.nik()) && String.length(Person.nik()) == 16
+    end
+  end
+end

--- a/test/neo_faker/id_id/person_test.exs
+++ b/test/neo_faker/id_id/person_test.exs
@@ -5,7 +5,7 @@ defmodule NeoFaker.IdId.PersonTest do
 
   describe "nik/0" do
     test "returns a random NIK" do
-      assert is_binary(Person.nik()) && String.length(Person.nik()) == 16
+      assert is_binary(Person.nik()) and String.length(Person.nik()) == 16
     end
   end
 end


### PR DESCRIPTION
This PR introduces the following changes:

- Add `NeoFaker.IdId.Person`, which provides functions for generating person-related information specific to the Indonesian locale.
- Add `NeoFaker.EnUs.Person`, which provides functions for generating person-related information specific to the United States locale.
- Add a module group for locale-specific random generators.