### PR TITLE
Fix and Refactor Locale Generator Modules

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,6 @@ import Config
 # This determines the language and regional data used by the library.
 # Available locales can be found at: https://hexdocs.pm/neo_faker/available-locales.html
 
-config :neo_faker, locale: :default
+if Mix.env() in [:dev, :test] do
+  config :neo_faker, locale: :default
+end

--- a/lib/data/locale.exs
+++ b/lib/data/locale.exs
@@ -1,0 +1,7 @@
+# This file is list of supported locales for NeoFaker.
+# To add a new locale, add it to this list and please sort it alphabetically.
+
+MapSet.new([
+  "en_us",
+  "id_id"
+])

--- a/lib/neo_faker/app.ex
+++ b/lib/neo_faker/app.ex
@@ -8,7 +8,7 @@ defmodule NeoFaker.App do
   @moduledoc since: "0.4.0"
 
   import NeoFaker.App.Util
-  import NeoFaker.Helper.Generator, only: [random: 4]
+  import NeoFaker.Locale.Generator
 
   alias NeoFaker.Person
 
@@ -56,7 +56,9 @@ defmodule NeoFaker.App do
 
   """
   @spec description(Keyword.t()) :: String.t()
-  def description(opts \\ []), do: random(__MODULE__, @description_file, "descriptions", opts)
+  def description(opts \\ []) do
+    random_data(__MODULE__, @description_file, "descriptions", opts)
+  end
 
   @doc """
   Generates a random open-source license.
@@ -71,7 +73,7 @@ defmodule NeoFaker.App do
 
   """
   @spec license() :: String.t()
-  def license, do: random(__MODULE__, @license_file, "licenses", [])
+  def license, do: random_data(__MODULE__, @license_file, "licenses")
 
   @doc """
   Generates a random app name.
@@ -114,10 +116,10 @@ defmodule NeoFaker.App do
   """
   @spec name(Keyword.t()) :: String.t()
   def name(opts \\ []) do
-    locale = Keyword.get(opts, :locale, :default)
+    locale = Keyword.get(opts, :locale)
     style = Keyword.get(opts, :style)
-    first_name = random(__MODULE__, @name_file, "first_names", locale: locale)
-    last_name = random(__MODULE__, @name_file, "last_names", locale: locale)
+    first_name = random_data(__MODULE__, @name_file, "first_names", locale: locale)
+    last_name = random_data(__MODULE__, @name_file, "last_names", locale: locale)
 
     name_case({first_name, last_name}, style)
   end
@@ -167,10 +169,5 @@ defmodule NeoFaker.App do
 
   """
   @spec version() :: String.t()
-  def version do
-    semver()
-    |> String.split(".")
-    |> Enum.take(2)
-    |> Enum.join(".")
-  end
+  def version, do: semver() |> String.split(".") |> Enum.take(2) |> Enum.join(".")
 end

--- a/lib/neo_faker/locale/cache.ex
+++ b/lib/neo_faker/locale/cache.ex
@@ -20,13 +20,18 @@ defmodule NeoFaker.Locale.Cache do
         "default" ->
           :persistent_term.put(
             create_persistent_term_key("default", module, file),
-            [@data_path, "default", module_name, file] |> Path.join() |> Disk.evaluate_file!()
+            [@data_path, "default", module_name, file]
+            |> Path.join()
+            |> Disk.evaluate_file!()
+            |> Map.new(fn {key, val} -> {key, Enum.shuffle(val)} end)
           )
 
         _ ->
           :persistent_term.put(
             create_persistent_term_key(locale_name, module, file),
-            Disk.evaluate_file!(file_path)
+            file_path
+            |> Disk.evaluate_file!()
+            |> Map.new(fn {key, val} -> {key, Enum.shuffle(val)} end)
           )
       end
     else

--- a/lib/neo_faker/locale/cache.ex
+++ b/lib/neo_faker/locale/cache.ex
@@ -1,0 +1,3 @@
+defmodule NeoFaker.Locale.Cache do
+  @moduledoc false
+end

--- a/lib/neo_faker/locale/cache.ex
+++ b/lib/neo_faker/locale/cache.ex
@@ -1,3 +1,47 @@
 defmodule NeoFaker.Locale.Cache do
   @moduledoc false
+
+  alias NeoFaker.Locale.Disk
+  alias NeoFaker.Locale.Resolver
+
+  @data_path Path.join([File.cwd!(), "lib", "data"])
+
+  @doc """
+  Create a persistent term with value in locale data file.
+  """
+  # @spec create_cache(atom(), atom(), String.t()) :: :ok
+  def create_cache(locale, module, file) do
+    locale_name = locale |> Resolver.resolve_locale_config() |> Atom.to_string()
+    module_name = module |> Module.split() |> List.last() |> String.downcase()
+    file_path = Path.join([@data_path, locale_name, module_name, file])
+
+    if File.exists?(file_path) do
+      case locale_name do
+        "default" ->
+          :persistent_term.put(
+            create_persistent_term_key("default", module, file),
+            [@data_path, "default", module_name, file] |> Path.join() |> Disk.evaluate_file!()
+          )
+
+        _ ->
+          :persistent_term.put(
+            create_persistent_term_key(locale_name, module, file),
+            Disk.evaluate_file!(file_path)
+          )
+      end
+    else
+      raise File.Error, reason: :enoent
+    end
+  end
+
+  @doc """
+  Creates a persistent term key based on the given locale, module, and file name.
+  """
+  @spec create_persistent_term_key(String.t(), atom(), String.t()) :: atom()
+  def create_persistent_term_key(locale, module, file) do
+    module_name = module |> Module.split() |> Enum.map_join("_", &String.downcase/1)
+    file_name = file |> String.split(".") |> List.first()
+
+    String.to_atom("#{module_name}_#{file_name}_#{locale}")
+  end
 end

--- a/lib/neo_faker/locale/disk.ex
+++ b/lib/neo_faker/locale/disk.ex
@@ -1,0 +1,18 @@
+defmodule NeoFaker.Locale.Disk do
+  @moduledoc false
+
+  @doc """
+  Evaluates the contents of a file and returns the result.
+  """
+  @spec evaluate_file!(String.t()) :: any()
+  def evaluate_file!(path) do
+    if File.exists?(path) do
+      path
+      |> File.read!()
+      |> Code.eval_string()
+      |> elem(0)
+    else
+      raise File.Error, reason: :enoent
+    end
+  end
+end

--- a/lib/neo_faker/locale/generator.ex
+++ b/lib/neo_faker/locale/generator.ex
@@ -1,0 +1,43 @@
+defmodule NeoFaker.Locale.Generator do
+  @moduledoc false
+
+  alias NeoFaker.Locale.Disk
+  alias NeoFaker.Locale.Resolver
+
+  @data_path Path.join([File.cwd!(), "lib", "data"])
+
+  @doc """
+  Generates a random value from the specified locale data file.
+
+  Returns a random value from the specified locale data file, locale doesnt exist or `nil` it will
+  return a random value from the default locale.
+
+  ## Parameters
+
+  - `module` - The module where the locale data is stored, e.g., `NeoFaker.App`.
+  - `file` - The name of the data file within the module, e.g., `"author.exs"`.
+  - `key` - The specific key within the data file, e.g., `"first_names"`, `"last_names"`.
+  - `opts` - Additional options.
+
+  ### Options
+
+  - `:locale` - Specifies the locale to use, e.g., `:id_id`. If not provided, `nil` will be used,
+  which loads the default locale.
+  """
+  @spec random(atom(), String.t(), String.t(), Keyword.t()) :: any()
+  def random(module, file, key, opts \\ []) do
+    module_name = module |> Module.split() |> List.last() |> String.downcase()
+    locale = Resolver.resolve_locale_config(opts)
+    file_path = Path.join([@data_path, locale, module_name, file])
+
+    if File.exists?(file_path) do
+      file_path |> Disk.evaluate_file!() |> Map.get(key) |> Enum.random()
+    else
+      [@data_path, "default", module_name, file]
+      |> Path.join()
+      |> Disk.evaluate_file!()
+      |> Map.get(key)
+      |> Enum.random()
+    end
+  end
+end

--- a/lib/neo_faker/locale/resolver.ex
+++ b/lib/neo_faker/locale/resolver.ex
@@ -9,18 +9,13 @@ defmodule NeoFaker.Locale.Resolver do
   @doc """
   Resolves the locale configuration based on the given options.
   """
-  @spec resolve_locale_config(Keyword.t()) :: String.t()
   def resolve_locale_config(opts) do
-    if is_nil(Keyword.get(opts, :locale)) do
+    if is_nil(opts) do
       :neo_faker
       |> Application.get_env(:locale)
       |> resolve_locale()
-      |> Atom.to_string()
     else
-      opts
-      |> Keyword.get(:locale)
-      |> resolve_locale()
-      |> Atom.to_string()
+      resolve_locale(opts)
     end
   end
 

--- a/lib/neo_faker/locale/resolver.ex
+++ b/lib/neo_faker/locale/resolver.ex
@@ -1,0 +1,34 @@
+defmodule NeoFaker.Locale.Resolver do
+  @moduledoc false
+
+  alias NeoFaker.Locale.Disk
+
+  @data_path Path.join([File.cwd!(), "lib", "data"])
+  @locale_file Path.join([@data_path, "locale.exs"])
+
+  @doc """
+  Resolves a locale based on the given locale.
+  """
+  @spec resolve_locale(atom()) :: atom()
+  def resolve_locale(locale) do
+    if locale_exists?(locale) do
+      locale
+    else
+      :default
+    end
+  end
+
+  @doc """
+  Checks if a locale exists in the locale.exs file.
+  """
+  @spec locale_exists?(atom()) :: boolean()
+  def locale_exists?(locale) do
+    if is_nil(:persistent_term.get(:available_locales, nil)) do
+      :persistent_term.put(:available_locales, MapSet.new(Disk.evaluate_file!(@locale_file)))
+
+      :available_locales |> :persistent_term.get() |> MapSet.member?(Atom.to_string(locale))
+    else
+      :available_locales |> :persistent_term.get() |> MapSet.member?(Atom.to_string(locale))
+    end
+  end
+end

--- a/lib/neo_faker/locale/resolver.ex
+++ b/lib/neo_faker/locale/resolver.ex
@@ -7,6 +7,24 @@ defmodule NeoFaker.Locale.Resolver do
   @locale_file Path.join([@data_path, "locale.exs"])
 
   @doc """
+  Resolves the locale configuration based on the given options.
+  """
+  @spec resolve_locale_config(Keyword.t()) :: String.t()
+  def resolve_locale_config(opts) do
+    if is_nil(Keyword.get(opts, :locale)) do
+      :neo_faker
+      |> Application.get_env(:locale)
+      |> resolve_locale()
+      |> Atom.to_string()
+    else
+      opts
+      |> Keyword.get(:locale)
+      |> resolve_locale()
+      |> Atom.to_string()
+    end
+  end
+
+  @doc """
   Resolves a locale based on the given locale.
   """
   @spec resolve_locale(atom()) :: atom()

--- a/test/neo_faker/date_test.exs
+++ b/test/neo_faker/date_test.exs
@@ -5,11 +5,12 @@ defmodule NeoFaker.DateTest do
 
   describe "add/2" do
     test "returns a random date in Date format" do
-      assert FakeDate.add(0..0) == Date.utc_today()
+      assert FakeDate.add(0..0) == NaiveDateTime.to_date(NaiveDateTime.local_now())
     end
 
     test "returns a random date in ISO 8601 format" do
-      assert FakeDate.add(0..0, format: :iso8601) == Date.to_iso8601(Date.utc_today())
+      assert FakeDate.add(0..0, format: :iso8601) ==
+               NaiveDateTime.local_now() |> NaiveDateTime.to_date() |> Date.to_iso8601()
     end
   end
 


### PR DESCRIPTION
This PR fixes the issue where the locale random generator couldn't automatically fetch locale data, even when it was properly set in config.exs.

It also includes a refactoring of the Locale Generator modules by separating functions based on their context for better clarity and maintainability.